### PR TITLE
test: Fixed path issue in httpLogger.test.ts for cross-platform compatibility

### DIFF
--- a/tests/unit/middlewares/httpLogger.test.ts
+++ b/tests/unit/middlewares/httpLogger.test.ts
@@ -1,18 +1,24 @@
+import path from 'path';
 import httpLogger from '@/middlewares/httpLogger';
 import Logger from '@/packages/logger';
 import { LOGGER_CONFIG } from '@/types/logger';
 import { JoorRequest } from '@/types/request';
+
 jest.mock('@/packages/logger');
+
 describe('httpLogger Middleware', () => {
   let mockedLoggerInstance: { info: jest.Mock };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockedLoggerInstance = { info: jest.fn() };
     (Logger as jest.Mock).mockImplementation(() => mockedLoggerInstance);
   });
+
   afterEach(() => {
     jest.resetAllMocks();
   });
+
   it('should initialize Logger with default configuration when no config is provided', () => {
     const logRequest = httpLogger();
 
@@ -22,18 +28,22 @@ describe('httpLogger Middleware', () => {
       httpVersion: '1.1',
       headers: {},
     } as JoorRequest;
+
     logRequest(fakeRequest);
+
     expect(Logger).toHaveBeenCalledTimes(1);
     expect(Logger).toHaveBeenCalledWith({
       name: 'HTTP',
-      path: expect.stringContaining('logs/http.log'),
+      path: expect.stringContaining(path.normalize('logs/http.log')), // ✅ Fix here
       formatCallBack: undefined,
     });
+
     expect(mockedLoggerInstance.info).toHaveBeenCalledTimes(1);
     expect(mockedLoggerInstance.info).toHaveBeenCalledWith(
       'GET /test-endpoint 1.1'
     );
   });
+
   it('should initialize Logger with provided configuration', () => {
     const customConfig: LOGGER_CONFIG = {
       name: 'CustomLogger',
@@ -49,7 +59,9 @@ describe('httpLogger Middleware', () => {
       httpVersion: '2.0',
       headers: {},
     } as JoorRequest;
+
     logRequest(fakeRequest);
+
     expect(Logger).toHaveBeenCalledTimes(1);
     expect(Logger).toHaveBeenCalledWith(customConfig);
     expect(mockedLoggerInstance.info).toHaveBeenCalledTimes(1);
@@ -57,6 +69,7 @@ describe('httpLogger Middleware', () => {
       'POST /api/data 2.0'
     );
   });
+
   it('should log request details correctly for different HTTP methods and URLs', () => {
     const logRequest = httpLogger();
 
@@ -65,6 +78,7 @@ describe('httpLogger Middleware', () => {
       { method: 'PUT', url: '/api/items/456', httpVersion: '2.0' },
       { method: 'PATCH', url: '/users/profile', httpVersion: '1.1' },
     ];
+
     testCases.forEach(({ method, url, httpVersion }) => {
       const fakeRequest = {
         method,
@@ -72,11 +86,14 @@ describe('httpLogger Middleware', () => {
         httpVersion,
         headers: {},
       } as JoorRequest;
+
       logRequest(fakeRequest);
+
       expect(mockedLoggerInstance.info).toHaveBeenCalledWith(
         `${method} ${url} ${httpVersion}`
       );
     });
+
     expect(mockedLoggerInstance.info).toHaveBeenCalledTimes(testCases.length);
   });
 });


### PR DESCRIPTION
Fixed a test failure in httpLogger.test.ts cause by different file path formats on Windows vs. Unix-based systems.
Use path.normalize('logs/http.log') to ensure compatibility across all operating systems.
