### PR TITLE
#Bug: Fixed path issue in httpLogger.test.ts for cross-platform compatibility

### DIFF
--- a/tests/unit/middlewares/httpLogger.test.ts
+++ b/tests/unit/middlewares/httpLogger.test.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import httpLogger from '@/middlewares/httpLogger';
 import Logger from '@/packages/logger';
 import { LOGGER_CONFIG } from '@/types/logger';
@@ -26,7 +28,7 @@ describe('httpLogger Middleware', () => {
     expect(Logger).toHaveBeenCalledTimes(1);
     expect(Logger).toHaveBeenCalledWith({
       name: 'HTTP',
-      path: expect.stringContaining('logs/http.log'),
+      path: expect.stringContaining(path.normalize('logs/http.log')), // ✅ Fix here
       formatCallBack: undefined,
     });
     expect(mockedLoggerInstance.info).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
Fixed a test failure in httpLogger.test.ts caused by different file path formats on Windows vs. Unix-based systems.
Used path.normalize('logs/http.log') to ensure compatibility across all operating systems.