### PR TITLE
 fix: Removed  ```Jrror``` from `src/index.ts` import/export  (#58)

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,9 @@
   },
   "dependencies": {
     "mime-type": "^5.0.2",
-    "mime-types": "^2.1.35"
+    "mime-types": "^2.1.35",
+    "tsx": "^4.19.2",
+    "ws": "^8.18.0"
   },
   "exports": {
     "./middlewares": "./src/middlewares/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import Jrror from '@/core/error';
 import Joor from '@/core/joor';
 import JoorResponse from '@/core/response';
 import Router from '@/core/router';
@@ -14,7 +13,6 @@ export default Joor;
 
 export {
   Joor,
-  Jrror,
   Router,
   JoorRequest,
   JoorResponse,


### PR DESCRIPTION
Removed the import/export of ```Jrror```, which was no longer needed.